### PR TITLE
Add pause between inverter read cycles

### DIFF
--- a/GivTCP/read.py
+++ b/GivTCP/read.py
@@ -447,20 +447,21 @@ def self_run(loop_timer):
         time.sleep(1)
 
 def self_run2():
-    counter=0
-    runAll(True)
+    counter = 0
+    fullrefresh = True
     while True:
-        counter=counter+1
+        runAll(fullrefresh)
+        counter = counter + 1
         if exists(".forceFullRefresh"):
-            runAll(True)
+            fullrefresh = True
             os.remove(".forceFullRefresh")
-            counter=0
-        elif counter==20:
-            counter=0
-            runAll(True)
+            counter = 0
+        elif counter == 20:
+            counter = 0
+            fullrefresh = True
         else:
-            runAll(False)
-        time.sleep(1)
+            fullrefresh = False
+        time.sleep(int(GiV_Settings.selfRunLoopTimer))
 
 
 ####### Addiitonal Publish options can be added here. 

--- a/GivTCP/settings_template.py
+++ b/GivTCP/settings_template.py
@@ -20,3 +20,5 @@ class GiV_Settings:
     influxToken=""
     influxBucket="GivEnergy"
     influxOrg="GivTCP"
+#Other settings
+    selfRunLoopTimer = "10"         # Time in seconds to pause between inverter read cycles  

--- a/GivTCP/startup.sh
+++ b/GivTCP/startup.sh
@@ -23,7 +23,8 @@ then
     rm $FILE3    #delete file and re-create
 fi
 
-if [ -z "$INVERTOR_IP" ]; then
+if [ -z "$INVERTOR_IP" ]
+then
     echo 'IP not set in ENV'
     for i in 1 2 3
     do
@@ -64,6 +65,7 @@ printf "    influxToken=\"$INFLUX_TOKEN\"\n" >> $FILE
 printf "    influxBucket=\"$INFLUX_BUCKET\"\n" >> $FILE
 printf "    influxOrg=\"$INFLUX_ORG\"\n" >> $FILE
 printf "    HA_Auto_D=$HA_AUTO_D\n" >> $FILE 
+printf "    selfRunLoopTimer=\"$SELF_RUN_LOOP_TIMER\"\n" >>$FILE
 printf "    first_run= True\n" >> $FILE
 
 #TODO Update givTCP if a newer release is available
@@ -89,5 +91,3 @@ fi
 GUPORT=$(($GIVTCPINSTANCE+6344))
 echo Starting Gunicorn on port "$GUPORT"
 gunicorn -w 3 -b :"$GUPORT" GivTCP.REST:giv_api            #Use for on-demand read and control
-
-

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ From here your invertor data is available through either MQTT or REST as describ
 | ENV Name                | Example       |  Description                      |
 | ----------------------- | ------------- |  -------------------------------- |
 | INVERTOR_IP |192.168.10.1 | Docker container can auto detect Invertors if running on your host network. If this fails then add the IP manually to this ENV |
-| NUMBATTERIES | 1 | Number of battery units connected to the invertor |
+| NUM_BATTERIES | 1 | Number of battery units connected to the invertor |
 | MQTT_OUTPUT | True | Optional if set to True then MQTT_ADDRESS is required |
 | MQTT_ADDRESS | 127.0.0.1 | Optional (but required if OUTPUT is set to MQTT) |
 | MQTT_USERNAME | bob | Optional |
@@ -55,6 +55,7 @@ From here your invertor data is available through either MQTT or REST as describ
 | INFLUX_BUCKET |giv_bucket| Optional - If using influx this is data bucket to use|
 | INFLUX_ORG |giv_tcp| Optional - If using influx this is the org that the token is assigned to | 
 | HA_AUTO_D | True | Optional - If set to true and MQTT is enabled, it will publish Home Assistant Auto Discovery messages, which will allow Home Assistant to automagically create all entitites and devices to allow read and control of your Invertor |
+| SELF_RUN_LOOP_TIMER |10| Time in seconds to pause between inverter read cycles |
 
 ## GivTCP Read data
 


### PR DESCRIPTION
Added logic to pause for a configurable number of seconds between inverter read cycles.   Pre this change once one cycle finished there was a 1 second pause before the next cycle started.  A read cycle keeps the inverter busy and can cause other API requests including from the Giv Cloud to fail with Inverter busy. Putting a pause between read cycles provides some breathing space for other API requests. 